### PR TITLE
comment-out ARMA_DONT_USE_CXX11

### DIFF
--- a/src/config.h
+++ b/src/config.h
@@ -61,7 +61,7 @@
 #define ARMA_NO_DEBUG 1
 #endif
 
-#define ARMA_DONT_USE_CXX11 1
+//#define ARMA_DONT_USE_CXX11 1
 #define ARMA_DONT_USE_WRAPPER 1
 
 #endif


### PR DESCRIPTION
Hi David,

Conrad has prepared a first 10.1-RC1 release of Armadillo 10.1 which I bundled into a pre-release RcppArmadillo_0.10.0.1.0.tar.gz that is available from its repo and the [Rcpp-drat](http://rcppcore.github.io/drat/).

Armadillo now insists on C++11 as minimum standard. Given that R 4.0.* does the same, this is not much of a constraint. Your package, just like less than a handful of others, sets 'no C++11' explicitly which clashes. All it takes, as I verified, is to not say that. The PR here does that.

I hope you can apply the PR or a variant of it and update your package "soon" to allow RcppArmadillo to update to Armadillo 10.1.

Let us know if we can help.

Cheers, Dirk

/cc @conradsnicta